### PR TITLE
Change the format of the output list (tokens, start_time)

### DIFF
--- a/DELETION.py
+++ b/DELETION.py
@@ -4,8 +4,7 @@ import random
 
 #read in csv file, delete 20% of words from json manual transcript, output csv with altered manual transcript as new column
 df = pd.read_csv('C:/temp/ASRforAD.csv')
-#df['json_with_deletion'], df['json_deleted_words'] = df.apply(lambda df : pd.Series(test_fn(df['json_utterances_man'])), axis =1)
-df['json_man_with_deletion'] = df.apply(lambda df : del_fn(df['json_utterances_man']), axis =1)
+df = df.merge(df.json_utterances_man.apply(lambda s: pd.Series(del_fn(s))), left_index=True, right_index=True)
 df.to_csv('C:/temp/DELETION_ASRforAD.csv')
 
 print(df.head())
@@ -55,4 +54,4 @@ def del_words(transcript, del_rate):
     for i in range (len(transcript)):
         if i not in del_indx:          
             new_tr.append(transcript[i])
-    return new_tr
+    return del_w, new_tr

--- a/DELETION.py
+++ b/DELETION.py
@@ -8,9 +8,6 @@ df = df.merge(df.json_utterances_man.apply(lambda s: pd.Series(del_fn(s))), left
 df.to_csv('C:/temp/DELETION_ASRforAD.csv')
 
 print(df.head())
-print(len(df.iloc[2,5]))
-print(df.iloc[2,5])
-
 
 # main fn 
 def del_fn(df):
@@ -22,22 +19,29 @@ def store_tr(df_row):
     return tr
 
 #flatten the transcript list
-def flatten(transcript):    
+def flatten(transcript):
     flat_list = []
-    for sublist in transcript: 
-        for i in sublist['tokens']:
-            flat_list.append(i)            
+    for sublist in transcript:
+        for item in sublist:
+            if item == 'tokens':
+                flat_list.append(item)
+                for item in sublist['tokens']:
+                    flat_list.append(item)   
+            else:
+                flat_list.append(item)
+                flat_list.append(str(sublist['start_time']))
     return flat_list
 
-# function to count number of words in transcript
+#count number of words in transcript
 def word_count(transcript):
     cnt = 0
-    for i in range(len(transcript)):
-        if transcript[i]['type'] == 'word':
-            cnt +=1    
+    for i in range(len(transcript)):        
+        if type(transcript[i]) is dict:
+            if transcript[i]['type'] == 'word':
+                cnt +=1    
     return cnt
 
-#delete random words from the transcript, return new transcript
+#delete random words from the transcript, return new transcript and the list of deleted words
 def del_words(transcript, del_rate): 
     total_words = word_count(transcript)
     del_words = int(total_words * del_rate)
@@ -45,11 +49,12 @@ def del_words(transcript, del_rate):
     del_w = []
     while len(del_indx) < del_words:
         r=random.randint(0,total_words)
-        if r not in del_indx:                
-            if transcript[r]['type'] == 'word':
-                del_indx.append(r)
-                del_w.append([transcript[r]])
-    del_indx.sort()
+        if r not in del_indx:
+            if type(transcript[r]) is dict:
+                if transcript[r]['type'] == 'word':
+                    del_indx.append(r)
+                    del_w.append([transcript[r]])
+        del_indx.sort()
     new_tr = []    
     for i in range (len(transcript)):
         if i not in del_indx:          

--- a/DELETION.py
+++ b/DELETION.py
@@ -2,22 +2,33 @@ import pandas as pd
 import json
 import random
 
+#read in csv file, delete 20% of words from json manual transcript, output csv with altered manual transcript as new column
+df = pd.read_csv('C:/temp/ASRforAD.csv')
+#df['json_with_deletion'], df['json_deleted_words'] = df.apply(lambda df : pd.Series(test_fn(df['json_utterances_man'])), axis =1)
+df['json_man_with_deletion'] = df.apply(lambda df : del_fn(df['json_utterances_man']), axis =1)
+df.to_csv('C:/temp/DELETION_ASRforAD.csv')
 
-#read in csv file and store manual transcript in temp value
-df = pd.read_csv('C:/Users/toshiba/Documents/test.csv')
-print(df.head(3))
-tr = json.loads(df.iloc[0,2])
+print(df.head())
+print(len(df.iloc[2,5]))
+print(df.iloc[2,5])
 
-#function to flatten the transcript list
+
+# main fn 
+def del_fn(df):
+    return del_words(flatten(store_tr(df)), 0.2)
+
+#store json transcript
+def store_tr(df_row):       
+    tr = json.loads(df_row)
+    return tr
+
+#flatten the transcript list
 def flatten(transcript):    
     flat_list = []
     for sublist in transcript: 
         for i in sublist['tokens']:
-            flat_list.append(i)
+            flat_list.append(i)            
     return flat_list
-
-flat_tr = flatten(tr)
-print(len(flat_tr))
 
 # function to count number of words in transcript
 def word_count(transcript):
@@ -27,33 +38,20 @@ def word_count(transcript):
             cnt +=1    
     return cnt
 
-num_words = word_count(flat_tr)
-print(num_words)
-
-#create two lists: 1.deleted words, 2. indeces of deleted words
-del_rate = 0.2
-del_words = int(num_words * del_rate)
-ind_list=[]
-del_w = []
-
-while len(ind_list) < del_words:
-    r=random.randint(0,num_words)
-    if r not in list:                
-        if flat_tr[r]['type'] == 'word':
-            ind_list.append(r)
-            del_w.append([flat_tr[r]])
-    
-print(len(ind_list))
-print(len(del_w))
-print(del_w)
-print(ind_list)
-
-#create new transcript without the deleted words
-def new_tr(transcript, del_indx):    
+#delete random words from the transcript, return new transcript
+def del_words(transcript, del_rate): 
+    total_words = word_count(transcript)
+    del_words = int(total_words * del_rate)
+    del_indx=[]
+    del_w = []
+    while len(del_indx) < del_words:
+        r=random.randint(0,total_words)
+        if r not in del_indx:                
+            if transcript[r]['type'] == 'word':
+                del_indx.append(r)
+                del_w.append([transcript[r]])
     del_indx.sort()
-    new_tr = []
-    m = 0
-    i = 0
+    new_tr = []    
     for i in range (len(transcript)):
         if i not in del_indx:          
             new_tr.append(transcript[i])

--- a/DELETION.py
+++ b/DELETION.py
@@ -12,8 +12,8 @@ tr = json.loads(df.iloc[0,2])
 def flatten(transcript):    
     flat_list = []
     for sublist in transcript: 
-        for i in range(len(sublist['tokens'])):
-            flat_list.append(sublist['tokens'][i])
+        for i in sublist['tokens']:
+            flat_list.append(i)
     return flat_list
 
 flat_tr = flatten(tr)
@@ -30,27 +30,31 @@ def word_count(transcript):
 num_words = word_count(flat_tr)
 print(num_words)
 
-#generate list with random numbers
-def del_list(num_words, del_rate):    
-    del_words = int(num_words * del_rate)
-    list=[]
-    while len(list) < del_words:
-        r=random.randint(0,num_words)
-        if r not in list: 
-            list.append(r)
-    list.sort()
-    return list
+#create two lists: 1.deleted words, 2. indeces of deleted words
+del_rate = 0.2
+del_words = int(num_words * del_rate)
+ind_list=[]
+del_w = []
 
-del_indx = del_list(num_words, 0.2)
-print(del_indx)
+while len(ind_list) < del_words:
+    r=random.randint(0,num_words)
+    if r not in list:                
+        if flat_tr[r]['type'] == 'word':
+            ind_list.append(r)
+            del_w.append([flat_tr[r]])
     
-m = 0
-i = 0
-temp = []
-if len(temp) < (len(del_indx)):
-    if flat_tr[del_indx[i]]['type'] == 'word':
-        temp.append([flat_tr[del_indx[i]]])
-        i +=1
-       
-print(len(temp))
-print(temp)
+print(len(ind_list))
+print(len(del_w))
+print(del_w)
+print(ind_list)
+
+#create new transcript without the deleted words
+def new_tr(transcript, del_indx):    
+    del_indx.sort()
+    new_tr = []
+    m = 0
+    i = 0
+    for i in range (len(transcript)):
+        if i not in del_indx:          
+            new_tr.append(transcript[i])
+    return new_tr


### PR DESCRIPTION
Changes:
1. Updated flatten(), word_count() and del_words() functions to keen 'tokens', 'start_time' and corresponding start time in the output transcript
Outstanding:
1. Label two new colums
2. New transcript is in list format that contains 'tokens','words','start_time', start time value as its elements. Let me know if needs to be formatted  back to json
3. New transcript still includes 'tokens' and 'start_time' for  words that were dropped and originally were one-token-word. I will fix that once know if json format is needed